### PR TITLE
Fixed bug that allowed duplicate favorites

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -496,7 +496,9 @@ function addToFavs(event) {
 
     //The saved recipes are searched for a matching mealID
     
-    var findMatch = favorites.indexOf(recipeId)
+    var findMatch = favorites.map(item => item.id).indexOf(recipeId);
+    console.log(findMatch)
+    
     
 
     //If a match IS NOT found, the mealID is added to favorites and the array is saved to localstorage


### PR DESCRIPTION
This pull request fixes a bug that allowed a recipe to be added to favorites more than once. When the favorite button is clicked, if the item is already a favorite it will be removed.

[bugfix-duplicate-favs.webm](https://user-images.githubusercontent.com/110208272/211230163-8ada79a6-0495-4168-bdc6-976ad49d008b.webm)
